### PR TITLE
Set Security Guild as codeowner of security workflows

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
 * @coopnorge/platform-guild @coopnorge/security-guild
 
 CODEOWNERS                        @coopnorge/security-guild
+
+.github/workflows/security-* @coopnorge/security-guild


### PR DESCRIPTION

Closes: coopnorge/engineering-issues#133