### PR TITLE
Update the usage example to match the current  pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,39 +4,15 @@ The workflow executes supply chain security tools and reports the results.
 
 ## Usage
 
-### Pull Request Workflow
-
-```yaml
----
-name: Pull Request CI
-on:
-  push: {}
-  pull_request: {}
-  build:
-    runs-on: ubuntu-latest
-    needs:
-      - validate
-      - supply-chain-security-validation
-    steps:
-      - run: "echo SUCCESS"
-  supply-chain-security-validation:
-    name: Supply Chain Security Validation
-    uses: coopnorge/github-workflow-supply-chain-security-validation/.github/workflows/supply-chain-security-validation.yaml@main
-  validate:
-    name: Validate
-    runs-on: ubuntu-latest
-    steps:
-      - ...
-      - ...
-      - ...
-```
-
-### Scheduled Workflow
+Run the workflow on pull requests, pushes to any branch and on a nightly
+schedule on the default branch.
 
 ```yaml
 ---
 name: Security Scan
 on:
+  push: {}
+  pull_request: {}
   schedule:
     - cron: '0 0 * * *'
 jobs:


### PR DESCRIPTION
This workflow should be called from its own workflow in each repository.

Closes: coopnorge/github-workflow-supply-chain-security-validation#16
