### PR TITLE
Do not run code scanning on pull request events

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -36,6 +36,7 @@ jobs:
   code-scanning:
     name: CodeQL Scanning
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
The push and schedule events covers what is needed.
