### PR TITLE
Fix a bug with code scanning timeout

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -9,7 +9,7 @@ on:
         required: false
       code-scanning-timeout-minutes:
         default: 10
-        type: int
+        type: number
         required: false
       tfsec-code-scanning-category:
         default: tfsec-code-scanning
@@ -41,7 +41,7 @@ jobs:
   code-scanning:
     name: CodeQL Scanning
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.codeql-code-timeout-minutes }}
+    timeout-minutes: ${{ inputs.code-scanning-timeout-minutes }}
     if: github.event_name != 'pull_request'
     permissions:
       security-events: write


### PR DESCRIPTION
- set `code-scanning-timeout-minutes` type to `number`
- use `inputs.code-scanning-timeout-minutes` as a value for `timeout-minutes` parameter of `code-scanning` job