### PR TITLE
fix: Shorten job titles to fit GitHub's UI

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,5 +1,5 @@
 ---
-name: Security Scan
+name: Security
 on:
   push: {}
   pull_request: {}
@@ -7,5 +7,5 @@ on:
     - cron: '0 0 * * *'
 jobs:
   supply-chain-security-validation:
-    name: Supply Chain Security Validation
+    name: Supply Chain
     uses: coopnorge/github-workflow-supply-chain-security-validation/.github/workflows/supply-chain-security-validation.yaml@main

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -1,5 +1,5 @@
 ---
-name: Supply Chain Security Validation
+name: Supply Chain
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -62,7 +62,7 @@ jobs:
         uses: actions/dependency-review-action@v2
 
   code-scanning:
-    name: CodeQL Scanning
+    name: CodeQL Scan
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.code-scanning-timeout-minutes }}
     if: github.event_name != 'pull_request'
@@ -124,7 +124,7 @@ jobs:
           category: ${{ inputs.codeql-code-scanning-category }}
 
   tfsec:
-    name: tfsec Scanning
+    name: tfsec Scan
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     permissions:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ schedule on the default branch.
 
 ```yaml
 ---
-name: Security Scan
+name: Security
 on:
   push: {}
   pull_request: {}
@@ -17,7 +17,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   supply-chain-security-validation:
-    name: Supply Chain Security Validation
+    name: Supply Chain
     uses: coopnorge/github-workflow-supply-chain-security-validation/.github/workflows/supply-chain-security-validation.yaml@main
 ```
 


### PR DESCRIPTION
Shortens job titles to fit in GitHubs UI, so that one can differentiate between jobs by looking at a list without taking action to expand the title.

Fixes #52.

In order to propogate to repos that already use workflows with long titles, each repo must be updated.