### PR TITLE
Fix codeql-go-version

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -15,7 +15,7 @@ on:
         type: string
         required: false
       codeql-go-version:
-        default: 1.20
+        default: "1.20"
         type: string
         required: false
       codeql-java-version:


### PR DESCRIPTION
Even if the value is declared to be a string it must be quoted or we get
the version number 1.2.
