### PR TITLE
chore: bump go to 1.21, to allow for 3-part version-numbers in go.mod

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -19,7 +19,7 @@ on:
         type: string
         required: false
       codeql-go-version:
-        default: "1.20"
+        default: "1.21"
         type: string
         required: false
       codeql-java-version:


### PR DESCRIPTION
This is a quick fix to allow CodeQL to start accepting e.g. `go 1.21.1` in `go.mod` files. 

The proper fix is to solve #75, but this PR will at least allow 3-part version-numbers in `go.mod` files, since that is only supported in the tooling since go 1.21.