### PR TITLE
feat: Add caching of go-dependencies

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -107,6 +107,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.codeql-go-version }}
+          cache: true
+          cache-dependency-path: "**/go.sum"
       - name: Set Java version
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
See https://github.com/actions/setup-go/blob/main/docs/adrs/0000-caching-dependencies.md#example-of-real-use-cases

By default, setup-go only looks for a go.sum in the root, but in Coop we often have the go.mod/go.sum in sub-directories.
Caching will also be disabled by default in a future version of setup-go, so it's smart to explicitly enable it now.
