### PR TITLE
Update go setup and use stable version if not passed in arg

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -19,7 +19,7 @@ on:
         type: string
         required: false
       codeql-go-version:
-        default: "1.21"
+        default: "1.22"
         type: string
         required: false
       codeql-java-version:
@@ -103,10 +103,13 @@ jobs:
             const codeqlLanguages = ['cpp', 'csharp', 'go', 'ruby', 'python', 'java', 'javascript', 'typescript'];
             const languages = detectedLanguages.filter(language => codeqlLanguages.includes(language));
             return languages.join(',');
+      - name: "Determine Go version"
+        run: echo "GO_VERSION=${{ inputs.codeql-go-version || 'stable' }}" >> $GITHUB_ENV
       - name: Set Go version
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ inputs.codeql-go-version }}
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
           cache-dependency-path: "**/go.sum"
       - name: Set Java version

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -19,7 +19,6 @@ on:
         type: string
         required: false
       codeql-go-version:
-        default: "1.22"
         type: string
         required: false
       codeql-java-version:

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -103,7 +103,12 @@ jobs:
             const languages = detectedLanguages.filter(language => codeqlLanguages.includes(language));
             return languages.join(',');
       - name: "Determine Go version"
-        run: echo "GO_VERSION=${{ inputs.codeql-go-version || 'stable' }}" >> $GITHUB_ENV
+        run: |
+          if [ -z "${{ inputs.codeql-go-version }}" ]; then
+            echo "GO_VERSION=stable" >> $GITHUB_ENV
+          else
+            echo "GO_VERSION=${{ inputs.codeql-go-version }}" >> $GITHUB_ENV
+          fi
       - name: Set Go version
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -106,14 +106,16 @@ jobs:
         run: |
           if [ -z "${{ inputs.codeql-go-version }}" ]; then
             echo "GO_VERSION=stable" >> $GITHUB_ENV
+            echo "GO_CHECK_LATEST=true" >> $GITHUB_ENV
           else
             echo "GO_VERSION=${{ inputs.codeql-go-version }}" >> $GITHUB_ENV
+            echo "GO_CHECK_LATEST=false" >> $GITHUB_ENV
           fi
       - name: Set Go version
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          check-latest: true
+          check-latest: ${{ env.GO_CHECK_LATEST }}
           cache: true
           cache-dependency-path: "**/go.sum"
       - name: Set Java version


### PR DESCRIPTION
By default try use stable version or use needed from args

Example of CI Failing: https://github.com/coopnorge/member-customer-directory/actions/runs/8278922177/job/22652273532?pr=857#step:10:76