### PR TITLE
fix: Workaround for database download errors

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -164,6 +164,9 @@ jobs:
           scan-type: fs
           format: sarif
           output: trivy-results.sarif
+        env:
+          # Workaround for trivy failing with "Database download error, TOOMANYREQUESTS"
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
         if: steps.terraform_files.outputs.count != '0'
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Recently these errors have started appearing quite frequently. 

![image](https://github.com/user-attachments/assets/86f2cb4f-3466-44d1-a3b4-2355dfdecf10)

Open issue here: https://github.com/aquasecurity/trivy-action/issues/389

Trying a workaround mentioned by some users.