### PR TITLE
chore: Ignore library vulnerabilities checking

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -163,6 +163,8 @@ jobs:
         with:
           scan-type: fs
           format: sarif
+          scanners: vuln,secret,misconfig
+          vuln-type: os
           output: trivy-results.sarif
         env:
           # Workaround for trivy failing with "Database download error, TOOMANYREQUESTS"


### PR DESCRIPTION
Library vulnerabilities are covered by dependabot. Fixes https://github.com/coopnorge/github-workflow-supply-chain-security-validation/issues/90