### PR TITLE
feat: Remove support for ruby scanning

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -99,7 +99,7 @@ jobs:
             const detectedLanguages = '${{ steps.detected-languages.outputs.languages }}'.toLowerCase().split(',').map(language => {
               return getCodeQLLanguage(language)
             });
-            const codeqlLanguages = ['cpp', 'csharp', 'go', 'ruby', 'python', 'java', 'javascript', 'typescript'];
+            const codeqlLanguages = ['cpp', 'csharp', 'go', 'python', 'java', 'javascript', 'typescript'];
             const languages = detectedLanguages.filter(language => codeqlLanguages.includes(language));
             return languages.join(',');
       - name: "Determine Go version"


### PR DESCRIPTION
We don't use ruby and it is only detected because ios Podfiles are ruby files. fixes https://github.com/coopnorge/github-workflow-supply-chain-security-validation/issues/92