### PR TITLE
feat: Remove misconfig scanner

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -159,7 +159,7 @@ jobs:
         with:
           scan-type: fs
           format: sarif
-          scanners: vuln,secret,misconfig
+          scanners: vuln,secret
           vuln-type: os
           output: trivy-results.sarif
         env:


### PR DESCRIPTION
Since misconfig for terraform is already covered by terraform-validation, we don't need it for that. For kubernetes-validation, I have created an issue here: https://github.com/coopnorge/cloud-platform-team/issues/996