### PR TITLE
feat: Use trivy-cache-action to cache db

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -241,6 +241,8 @@ jobs:
         if: steps.cache-dbs.outcome == 'success'
 
       - name: Delete previous caches
+        # since the full db size is ~700 mb, it could easily exceed the repo limit of 10GB,
+        # so we delete older entries if newer entry is successful
         if: steps.cache-dbs.outcome == 'success'
         continue-on-error: true
         run: |

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -143,8 +143,81 @@ jobs:
         with:
           category: ${{ inputs.codeql-code-scanning-category }}
 
+  update-and-cache-trivy-db:
+    runs-on: ubuntu-latest
+    outputs:
+      trivy-db-sha: ${{ steps.trivy-db.outputs.sha }}
+      trivy-java-db-sha: ${{ steps.trivy-java-db.outputs.sha }}
+    steps:
+      - name: Setup oras
+        uses: oras-project/setup-oras@v1
+
+      - id: trivy-db
+        name: Check trivy db sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          endpoint='/orgs/aquasecurity/packages/container/trivy-db/versions'
+          headers='Accept: application/vnd.github+json'
+          jqFilter='.[] | select(.metadata.container.tags[] | contains("latest")) | .name | sub("sha256:";"")'
+          sha=$(gh api -H "${headers}" "${endpoint}" | jq --raw-output "${jqFilter}")
+          echo "Trivy DB sha256:${sha}"
+          echo "sha=${sha}" >> $GITHUB_OUTPUT
+
+      - id: trivy-java-db
+        name: Check trivy java db sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          endpoint='/orgs/aquasecurity/packages/container/trivy-db/versions'
+          headers='Accept: application/vnd.github+json'
+          jqFilter='.[] | select(.metadata.container.tags[] | contains("latest")) | .name | sub("sha256:";"")'
+          sha=$(gh api -H "${headers}" "${endpoint}" | jq --raw-output "${jqFilter}")
+          echo "Trivy Java DB sha256:${sha}"
+          echo "sha=${sha}" >> $GITHUB_OUTPUT
+
+      - id: cache
+        name: Restore Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}
+
+      - name: Cache Hit Check
+        run: |
+          echo "Cache hit: ${{ steps.cache.outputs.cache-hit }}"
+
+      - id: download-db
+        name: Download and extract the vulnerability DB
+        if: steps.cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
+          oras pull ghcr.io/aquasecurity/trivy-db:2
+          tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+          rm db.tar.gz
+
+      - id: download-java-db
+        name: Download and extract the Java DB
+        if: steps.cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
+          oras pull ghcr.io/aquasecurity/trivy-java-db:1
+          tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+          rm javadb.tar.gz
+
+      - id: cache-db
+        name: Cache DBs
+        if: steps.cache.outputs.cache-hit != 'true' && steps.download-db.outcome == 'success' && steps.download-java-db.outcome == 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}
+
   trivy:
     name: trivy Scan
+    needs: update-and-cache-trivy-db
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     permissions:
@@ -154,6 +227,17 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+      - id: restore-db-cache
+        name: Restore DB from cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ needs.update-and-cache-trivy-db.outputs.trivy-db-sha }}-${{ needs.update-and-cache-trivy-db.outputs.trivy-java-db-sha }}
+          restore-keys: cache-trivy-
+      - id: set-db-is-restored
+        run: |
+          # if any cache is restored, skip updating
+          echo "db-is-restored=$([[ -n '${{ steps.restore-db-cache.outputs.cache-matched-key }}' ]] && echo true || echo false)" >> $GITHUB_OUTPUT
       - name: trivy
         uses: aquasecurity/trivy-action@0.28.0
         with:
@@ -162,9 +246,11 @@ jobs:
           scanners: vuln,secret
           vuln-type: os
           output: trivy-results.sarif
+          # disable the default cache behavior
+          cache: false
         env:
-          # Workaround for trivy failing with "Database download error, TOOMANYREQUESTS"
-          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIVY_SKIP_DB_UPDATE: ${{ steps.set-db-is-restored.outputs.db-is-restored }}
+          TRIVY_SKIP_JAVA_DB_UPDATE: ${{ steps.set-db-is-restored.outputs.db-is-restored }}
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -149,9 +149,6 @@ jobs:
       trivy-db-sha: ${{ steps.trivy-db.outputs.sha }}
       trivy-java-db-sha: ${{ steps.trivy-java-db.outputs.sha }}
     steps:
-      - name: Setup oras
-        uses: oras-project/setup-oras@v1
-
       - id: trivy-db
         name: Check trivy db sha
         env:
@@ -187,13 +184,26 @@ jobs:
         run: |
           echo "Cache hit: ${{ steps.cache.outputs.cache-hit }}"
 
+      - name: Setup oras
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: oras-project/setup-oras@v1
+
       - id: download-db
         name: Download and extract the vulnerability DB
         if: steps.cache.outputs.cache-hit != 'true'
         continue-on-error: true
         run: |
           mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
-          oras pull ghcr.io/aquasecurity/trivy-db:2
+          # Try to download from public.ecr.aws first
+          if oras pull public.ecr.aws/aquasecurity/trivy-db:2; then
+            echo "Downloaded trivy-db from public.ecr.aws"
+          # If that fails, try ghcr.io
+          elif oras pull ghcr.io/aquasecurity/trivy-db:2; then
+            echo "Downloaded trivy-db from ghcr.io"
+          else
+            echo "Failed to download trivy-db from both registries."
+            exit 1  # Exit with failure if both downloads fail
+          fi
           tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
           rm db.tar.gz
 
@@ -203,7 +213,16 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
-          oras pull ghcr.io/aquasecurity/trivy-java-db:1
+          # Try to download from public.ecr.aws first
+          if oras pull public.ecr.aws/aquasecurity/trivy-java-db:1; then
+            echo "Downloaded trivy-java-db from public.ecr.aws"
+          # If that fails, try ghcr.io
+          elif oras pull ghcr.io/aquasecurity/trivy-java-db:1; then
+            echo "Downloaded trivy-java-db from ghcr.io"
+          else
+            echo "Failed to download trivy-java-db from both registries."
+            exit 1  # Exit with failure if both downloads fail
+          fi
           tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
           rm javadb.tar.gz
 

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -146,6 +146,9 @@ jobs:
   update-and-cache-trivy-db:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
+    env:
+      TRIVY_DB_VERSION: 2
+      TRIVY_JAVA_DB_VERSION: 1
     outputs:
       trivy-db-sha: ${{ steps.trivy-db.outputs.sha }}
       trivy-java-db-sha: ${{ steps.trivy-java-db.outputs.sha }}
@@ -157,7 +160,7 @@ jobs:
         run: |
           endpoint='/orgs/aquasecurity/packages/container/trivy-db/versions'
           headers='Accept: application/vnd.github+json'
-          jqFilter='.[] | select(.metadata.container.tags[] | contains("latest")) | .name | sub("sha256:";"")'
+          jqFilter='.[] | select(.metadata.container.tags[] | contains("$TRIVY_DB_VERSION")) | .name | sub("sha256:";"")'
           sha=$(gh api -H "${headers}" "${endpoint}" | jq --raw-output "${jqFilter}")
           echo "Trivy DB sha256:${sha}"
           echo "sha=${sha}" >> $GITHUB_OUTPUT
@@ -169,7 +172,7 @@ jobs:
         run: |
           endpoint='/orgs/aquasecurity/packages/container/trivy-java-db/versions'
           headers='Accept: application/vnd.github+json'
-          jqFilter='.[] | select(.metadata.container.tags[] | contains("latest")) | .name | sub("sha256:";"")'
+          jqFilter='.[] | select(.metadata.container.tags[] | contains("$TRIVY_JAVA_DB_VERSION")) | .name | sub("sha256:";"")'
           sha=$(gh api -H "${headers}" "${endpoint}" | jq --raw-output "${jqFilter}")
           echo "Trivy Java DB sha256:${sha}"
           echo "sha=${sha}" >> $GITHUB_OUTPUT
@@ -196,10 +199,10 @@ jobs:
         run: |
           mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
           # Try to download from public.ecr.aws first
-          if oras pull public.ecr.aws/aquasecurity/trivy-db:2; then
+          if oras pull public.ecr.aws/aquasecurity/trivy-db:$TRIVY_DB_VERSION; then
             echo "Downloaded trivy-db from public.ecr.aws"
           # If that fails, try ghcr.io
-          elif oras pull ghcr.io/aquasecurity/trivy-db:2; then
+          elif oras pull ghcr.io/aquasecurity/trivy-db:$TRIVY_DB_VERSION; then
             echo "Downloaded trivy-db from ghcr.io"
           else
             echo "Failed to download trivy-db from both registries."
@@ -215,10 +218,10 @@ jobs:
         run: |
           mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
           # Try to download from public.ecr.aws first
-          if oras pull public.ecr.aws/aquasecurity/trivy-java-db:1; then
+          if oras pull public.ecr.aws/aquasecurity/trivy-java-db:$TRIVY_JAVA_DB_VERSION; then
             echo "Downloaded trivy-java-db from public.ecr.aws"
           # If that fails, try ghcr.io
-          elif oras pull ghcr.io/aquasecurity/trivy-java-db:1; then
+          elif oras pull ghcr.io/aquasecurity/trivy-java-db:$TRIVY_JAVA_DB_VERSION; then
             echo "Downloaded trivy-java-db from ghcr.io"
           else
             echo "Failed to download trivy-java-db from both registries."

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -254,13 +254,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         continue-on-error: true
         run: |
-          # get ids for all old custom-trivy-cache entries
-          ids=$(gh cache list | grep 'custom-cache-trivy-' | grep -v 'custom-cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}' | awk '{print $1}')
-          IFS=',' read -ra ID_ARRAY <<< "$ids"
-          for id in "${ID_ARRAY[@]}"; do
+          # Get IDs for all old "custom-cache-trivy" entries, except for the one that was just cached, and delete them
+          ids=$(gh cache list | grep 'custom-cache-trivy-' | grep -v "custom-cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}" | awk '{print $1}')
+          while IFS= read -r id; do
             echo "Deleting stale cache with id $id"
             gh cache delete "$id"
-          done
+          done <<< "$ids"
 
   trivy:
     name: trivy Scan

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -245,7 +245,7 @@ jobs:
 
       - name: Delete previous caches
         # since the full db size is ~700 mb, it could easily exceed the repo limit of 10GB,
-        # so we delete older entries if newer entry is successful
+        # so we delete older entries if newer entry is successfully cached
         if: steps.cache-dbs.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -244,6 +244,8 @@ jobs:
         # since the full db size is ~700 mb, it could easily exceed the repo limit of 10GB,
         # so we delete older entries if newer entry is successful
         if: steps.cache-dbs.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
         continue-on-error: true
         run: |
           # get ids for all old custom-trivy-cache entries

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -145,6 +145,7 @@ jobs:
 
   update-and-cache-trivy-db:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     outputs:
       trivy-db-sha: ${{ steps.trivy-db.outputs.sha }}
       trivy-java-db-sha: ${{ steps.trivy-java-db.outputs.sha }}
@@ -228,7 +229,7 @@ jobs:
 
       - id: cache-dbs
         name: Cache DBs
-        if: steps.restore-db-cache.outputs.cache-hit != 'true' && steps.download-db.outcome == 'success' && steps.download-java-db.outcome == 'success'
+        if: steps.download-db.outcome == 'success' && steps.download-java-db.outcome == 'success'
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/.cache/trivy
@@ -237,10 +238,10 @@ jobs:
       - name: Checkout
         # this step is needed for gh cache list in the next step
         uses: actions/checkout@v4
-        if: steps.restore-db-cache.outputs.cache-hit != 'true' && steps.cache-dbs.outcome == 'success'
+        if: steps.cache-dbs.outcome == 'success'
 
       - name: Delete previous caches
-        if: steps.restore-db-cache.outputs.cache-hit != 'true' && steps.cache-dbs.outcome == 'success'
+        if: steps.cache-dbs.outcome == 'success'
         continue-on-error: true
         run: |
           # get ids for all old custom-trivy-cache entries

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -180,7 +180,7 @@ jobs:
           ids=$(gh cache list | grep 'custom-cache-trivy-' | awk '{print $1}')
           echo "cache_ids=${ids}" >> $GITHUB_OUTPUT
 
-      - id: cache-db
+      - id: restore-db-cache
         name: Restore Cache
         uses: actions/cache/restore@v4
         with:
@@ -189,15 +189,15 @@ jobs:
 
       - name: Cache Hit Check
         run: |
-          echo "Latest db version already in cache: ${{ steps.cache.outputs.cache-hit }}. Skipping db download."
+          echo "Latest db version already in cache: ${{ steps.restore-db-cache.outputs.cache-hit }}. Skipping db download."
 
       - name: Setup oras
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.restore-db-cache.outputs.cache-hit != 'true'
         uses: oras-project/setup-oras@v1
 
       - id: download-db
         name: Download and extract the vulnerability DB
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.restore-db-cache.outputs.cache-hit != 'true'
         continue-on-error: true
         run: |
           mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
@@ -216,7 +216,7 @@ jobs:
 
       - id: download-java-db
         name: Download and extract the Java DB
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.restore-db-cache.outputs.cache-hit != 'true'
         continue-on-error: true
         run: |
           mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
@@ -233,16 +233,16 @@ jobs:
           tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
           rm javadb.tar.gz
 
-      - id: cache-db
+      - id: cache-dbs
         name: Cache DBs
-        if: steps.cache.outputs.cache-hit != 'true' && steps.download-db.outcome == 'success' && steps.download-java-db.outcome == 'success'
+        if: steps.restore-db-cache.outputs.cache-hit != 'true' && steps.download-db.outcome == 'success' && steps.download-java-db.outcome == 'success'
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/.cache/trivy
           key: custom-cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}
 
       - name: Delete previous caches
-        if: steps.cache.outputs.cache-hit != 'true' && steps.cache-db.outcome == 'success'
+        if: steps.restore-db-cache.outputs.cache-hit != 'true' && steps.cache-dbs.outcome == 'success'
         continue-on-error: true
         run: |
           ids="${{ steps.previous-trivy-cache-ids.outputs.cache_ids }}"

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -160,8 +160,8 @@ jobs:
         run: |
           endpoint='/orgs/aquasecurity/packages/container/trivy-db/versions'
           headers='Accept: application/vnd.github+json'
-          jqFilter='.[] | select(.metadata.container.tags[] | contains("$TRIVY_DB_VERSION")) | .name | sub("sha256:";"")'
-          sha=$(gh api -H "${headers}" "${endpoint}" | jq --raw-output "${jqFilter}")
+          jqFilter='.[] | select(.metadata.container.tags[] | contains($TRIVY_DB_VERSION)) | .name | sub("sha256:";"")'
+          sha=$(gh api -H "${headers}" "${endpoint}" | jq --arg TRIVY_DB_VERSION "$TRIVY_DB_VERSION" --raw-output "${jqFilter}")
           echo "Trivy DB sha256:${sha}"
           echo "sha=${sha}" >> $GITHUB_OUTPUT
 
@@ -172,8 +172,8 @@ jobs:
         run: |
           endpoint='/orgs/aquasecurity/packages/container/trivy-java-db/versions'
           headers='Accept: application/vnd.github+json'
-          jqFilter='.[] | select(.metadata.container.tags[] | contains("$TRIVY_JAVA_DB_VERSION")) | .name | sub("sha256:";"")'
-          sha=$(gh api -H "${headers}" "${endpoint}" | jq --raw-output "${jqFilter}")
+          jqFilter='.[] | select(.metadata.container.tags[] | contains($TRIVY_JAVA_DB_VERSION)) | .name | sub("sha256:";"")'
+          sha=$(gh api -H "${headers}" "${endpoint}" | jq --arg TRIVY_JAVA_DB_VERSION "$TRIVY_JAVA_DB_VERSION" --raw-output "${jqFilter}")
           echo "Trivy Java DB sha256:${sha}"
           echo "sha=${sha}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -173,6 +173,8 @@ jobs:
           echo "Trivy Java DB sha256:${sha}"
           echo "sha=${sha}" >> $GITHUB_OUTPUT
 
+      - uses: actions/checkout@v4
+
       - id: previous-trivy-cache-ids
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -173,15 +173,6 @@ jobs:
           echo "Trivy Java DB sha256:${sha}"
           echo "sha=${sha}" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v4
-
-      - id: previous-trivy-cache-ids
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ids=$(gh cache list | grep 'custom-cache-trivy-' | awk '{print $1}')
-          echo "cache_ids=${ids}" >> $GITHUB_OUTPUT
-
       - id: restore-db-cache
         name: Restore Cache
         uses: actions/cache/restore@v4
@@ -243,11 +234,17 @@ jobs:
           path: ${{ github.workspace }}/.cache/trivy
           key: custom-cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}
 
+      - name: Checkout
+        # this step is needed for gh cache list in the next step
+        uses: actions/checkout@v4
+        if: steps.restore-db-cache.outputs.cache-hit != 'true' && steps.cache-dbs.outcome == 'success'
+
       - name: Delete previous caches
         if: steps.restore-db-cache.outputs.cache-hit != 'true' && steps.cache-dbs.outcome == 'success'
         continue-on-error: true
         run: |
-          ids="${{ steps.previous-trivy-cache-ids.outputs.cache_ids }}"
+          # get ids for all old custom-trivy-cache entries
+          ids="gh cache list | grep 'custom-cache-trivy-' | grep -v 'custom-cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}' | awk '{print $1}'"
           IFS=',' read -ra ID_ARRAY <<< "$ids"
           for id in "${ID_ARRAY[@]}"; do
             echo "Deleting stale cache with id $id"

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -152,6 +152,9 @@ jobs:
     outputs:
       trivy-db-sha: ${{ steps.trivy-db.outputs.sha }}
       trivy-java-db-sha: ${{ steps.trivy-java-db.outputs.sha }}
+    permissions:
+      contents: read # required for checkout, which is required for cache delete
+      actions: write # required to delete cache
     steps:
       - id: trivy-db
         name: Check trivy db sha

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -249,7 +249,7 @@ jobs:
         continue-on-error: true
         run: |
           # get ids for all old custom-trivy-cache entries
-          ids="gh cache list | grep 'custom-cache-trivy-' | grep -v 'custom-cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}' | awk '{print $1}'"
+          ids=$(gh cache list | grep 'custom-cache-trivy-' | grep -v 'custom-cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}' | awk '{print $1}')
           IFS=',' read -ra ID_ARRAY <<< "$ids"
           for id in "${ID_ARRAY[@]}"; do
             echo "Deleting stale cache with id $id"

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -173,7 +173,7 @@ jobs:
           echo "Trivy Java DB sha256:${sha}"
           echo "sha=${sha}" >> $GITHUB_OUTPUT
 
-      - id: cache
+      - id: cache-db
         name: Restore Cache
         uses: actions/cache/restore@v4
         with:
@@ -182,7 +182,7 @@ jobs:
 
       - name: Cache Hit Check
         run: |
-          echo "Cache hit: ${{ steps.cache.outputs.cache-hit }}"
+          echo "Latest db version already in cache: ${{ steps.cache.outputs.cache-hit }}. Skipping db download."
 
       - name: Setup oras
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -173,12 +173,19 @@ jobs:
           echo "Trivy Java DB sha256:${sha}"
           echo "sha=${sha}" >> $GITHUB_OUTPUT
 
+      - id: previous-trivy-cache-ids
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ids=$(gh cache list | grep 'custom-cache-trivy-' | awk '{print $1}')
+          echo "cache_ids=${ids}" >> $GITHUB_OUTPUT
+
       - id: cache-db
         name: Restore Cache
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.cache/trivy
-          key: cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}
+          key: custom-cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}
 
       - name: Cache Hit Check
         run: |
@@ -232,7 +239,18 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/.cache/trivy
-          key: cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}
+          key: custom-cache-trivy-${{ steps.trivy-db.outputs.sha }}-${{ steps.trivy-java-db.outputs.sha }}
+
+      - name: Delete previous caches
+        if: steps.cache.outputs.cache-hit != 'true' && steps.cache-db.outcome == 'success'
+        continue-on-error: true
+        run: |
+          ids="${{ steps.previous-trivy-cache-ids.outputs.cache_ids }}"
+          IFS=',' read -ra ID_ARRAY <<< "$ids"
+          for id in "${ID_ARRAY[@]}"; do
+            echo "Deleting stale cache with id $id"
+            gh cache delete "$id"
+          done
 
   trivy:
     name: trivy Scan
@@ -251,8 +269,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/.cache/trivy
-          key: cache-trivy-${{ needs.update-and-cache-trivy-db.outputs.trivy-db-sha }}-${{ needs.update-and-cache-trivy-db.outputs.trivy-java-db-sha }}
-          restore-keys: cache-trivy-
+          key: custom-cache-trivy-${{ needs.update-and-cache-trivy-db.outputs.trivy-db-sha }}-${{ needs.update-and-cache-trivy-db.outputs.trivy-java-db-sha }}
+          restore-keys: custom-cache-trivy-
       - id: set-db-is-restored
         run: |
           # if any cache is restored, skip updating

--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -166,7 +166,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          endpoint='/orgs/aquasecurity/packages/container/trivy-db/versions'
+          endpoint='/orgs/aquasecurity/packages/container/trivy-java-db/versions'
           headers='Accept: application/vnd.github+json'
           jqFilter='.[] | select(.metadata.container.tags[] | contains("latest")) | .name | sub("sha256:";"")'
           sha=$(gh api -H "${headers}" "${endpoint}" | jq --raw-output "${jqFilter}")


### PR DESCRIPTION
This implementation caches as often as db update is available and restores as far back as it can go (7 days is the behavior in Github Actions) and falls back to letting it download db if there is nothing to restore.

ref: https://github.com/coopnorge/cloud-platform-team/issues/997