### PR TITLE
chore: Don't hash-pin official actions from GitHub

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -59,9 +59,9 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@v4
       - name: Dependency Review
-        uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # pin@v4
+        uses: actions/dependency-review-action@v4
 
   code-scanning:
     name: CodeQL Scan
@@ -75,14 +75,14 @@ jobs:
       packages: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@v4
       - name: Configure access to internal and private GitHub repos
         run: git config --global url."https://${{ secrets.REVIEWBOT_GITHUB_TOKEN }}:x-oauth-basic@github.com/coopnorge".insteadOf "https://github.com/coopnorge"
       - uses: fabasoad/setup-enry-action@8c3105eb3007cc1e2439218a4345ed7e87954f70 # pin@main
       - name: Detected Languages
         id: detected-languages
         run: echo "languages=$(enry | awk -F ' ' '{print $2}' | paste -sd ',' -)" >> $GITHUB_OUTPUT
-      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pin@v7
+      - uses: actions/github-script@v7
         name: Get CodeQL supported languages
         id: languages
         with:
@@ -119,21 +119,21 @@ jobs:
             echo "GO_CHECK_LATEST=false" >> $GITHUB_ENV
           fi
       - name: Set Go version
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # pin@v5
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: ${{ env.GO_CHECK_LATEST }}
           cache: true
           cache-dependency-path: "**/go.sum"
       - name: Set Java version
-        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # pin@v4
+        uses: actions/setup-java@v4
         with:
           distribution: ${{ inputs.codeql-java-distribution }}
           java-version: ${{ inputs.codeql-java-version }}
           cache: ${{ inputs.codeql-java-cache }}
       - name: Initialize CodeQL
         if: steps.languages.outputs.result != '""'
-        uses: github/codeql-action/init@6bb031afdd8eb862ea3fc1848194185e076637e5 # pin@v3
+        uses: github/codeql-action/init@v3
         with:
           config-file: ${{ inputs.codeql-code-scanning-config-file }}
           languages: ${{ fromJSON(steps.languages.outputs.result) }}
@@ -143,10 +143,10 @@ jobs:
           dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/coopnorge/index.json"
       - name: Autobuild
         if: steps.languages.outputs.result != '""'
-        uses: github/codeql-action/autobuild@6bb031afdd8eb862ea3fc1848194185e076637e5 # pin@v3
+        uses: github/codeql-action/autobuild@v3
       - name: Perform CodeQL Analysis
         if: steps.languages.outputs.result != '""'
-        uses: github/codeql-action/analyze@6bb031afdd8eb862ea3fc1848194185e076637e5 # pin@v3
+        uses: github/codeql-action/analyze@v3
         with:
           category: ${{ inputs.codeql-code-scanning-category }}
 
@@ -160,7 +160,7 @@ jobs:
       contents: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@v4
       - name: trivy
         uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # pin@0.29.0
         with:
@@ -170,7 +170,7 @@ jobs:
           vuln-type: os
           output: trivy-results.sarif
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@6bb031afdd8eb862ea3fc1848194185e076637e5 # pin@v3
+        uses: github/codeql-action/upload-sarif@v3
         with:
           category: ${{ inputs.trivy-code-scanning-category }}
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
CodeQL scan doesn't complain on official actions.