### PR TITLE
feat: add ability to inject maven settings to security workflow

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -109,6 +109,7 @@ jobs:
             const codeqlLanguages = ['c', 'cpp', 'csharp', 'go', 'python', 'java', 'javascript', 'typescript', 'actions'];
             const languages = detectedLanguages.filter(language => codeqlLanguages.includes(language));
             return languages.join(',');
+      
       - name: "Determine Go version"
         run: |
           if [ -z "${{ inputs.codeql-go-version }}" ]; then
@@ -125,12 +126,21 @@ jobs:
           check-latest: ${{ env.GO_CHECK_LATEST }}
           cache: true
           cache-dependency-path: "**/go.sum"
+      
       - name: Set Java version
         uses: actions/setup-java@v5
         with:
           distribution: ${{ inputs.codeql-java-distribution }}
           java-version: ${{ inputs.codeql-java-version }}
           cache: ${{ inputs.codeql-java-cache }}
+      - name: Setup Maven settings
+        if: ${{ env.MAVEN_SETTINGS != '' }}
+        env: 
+          MAVEN_SETTINGS: ${{ secrets.MAVEN_SETTINGS_BASE64 }}
+        run: |
+          mkdir -p ~/.m2
+          echo $MAVEN_SETTINGS | base64 -d > ~/.m2/settings.xml
+            
       - name: Initialize CodeQL
         if: steps.languages.outputs.result != '""'
         uses: github/codeql-action/init@v3

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ jobs:
     uses: coopnorge/github-workflow-supply-chain-security-validation/.github/workflows/supply-chain-security-validation.yaml@main
 ```
 
+### Maven 
+
+If you add a secret called `MAVEN_SETTINGS_BASE64` and fill it with a base64
+encoded maven `settings.xml` it will write the maven settings to
+`~/.m2/settings.xml` 
+
 ### Parameters
 
 #### `codeql-code-scanning-config-file`


### PR DESCRIPTION
This will add a feature to add maven settings (mainly access to private
repos) via an base64 encoded settings.xml

Signed-off-by: Atze de Vries <atze.wiebe.de.vries@coop.no>
