### PR TITLE
chore: Don't setup java if java is not detected

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -145,6 +145,7 @@ jobs:
           cache-dependency-path: "**/go.sum"
       
       - name: Set Java version
+        if: contains(steps.languages.outputs.result, 'java')
         uses: actions/setup-java@v5
         with:
           distribution: ${{ inputs.codeql-java-distribution }}


### PR DESCRIPTION
setup-java was failing when cloudflare was down and therefore failing for all repos which don't even have java.