### PR TITLE
Add cgo script support - byo

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -128,6 +128,8 @@ jobs:
             });
 
             // Always scan for actions
+            // Enry does not find GitHub actions and they always exist if this workflow is running
+            // So, always add it.
             detectedLanguages.push('actions');
 
             const codeqlLanguages = ['c', 'cpp', 'csharp', 'go', 'python', 'java', 'javascript', 'typescript', 'actions'];


### PR DESCRIPTION
this is the pr that adds support for:

- Support for a cgo dependencies installation
- Support to specify a specific language instead of autobuild

There are some interesting caveats. Both are required for cgo because for example: Enri and Autobuild detect the project to be a cpp project. which was causing issues when trying to run code scanning for go.

Dependencies for cgo are quite specific to the project. 