### PR TITLE
chore: Specify trivy-version in trivy-action

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -182,6 +182,7 @@ jobs:
           scanners: vuln,secret
           vuln-type: os
           output: trivy-results.sarif
+          version: v0.69.2
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4
         with:


### PR DESCRIPTION
https://github.com/coopnorge/github-workflow-renovate/actions/runs/22568381656/job/65369917918?pr=32

Will add renovate rule to update this later.

