### PR TITLE
feat: make validation skip on non failure and use cheaper instance

### DIFF
--- a/.github/workflows/supply-chain-security-validation.yaml
+++ b/.github/workflows/supply-chain-security-validation.yaml
@@ -44,8 +44,8 @@ on:
 jobs:
   validate:
     name: Validate
-    if: always()
-    runs-on: ubuntu-24.04
+    if: ${{ contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled') }}
+    runs-on: ubuntu-slim
     permissions: {}
     needs:
       - dependency-review
@@ -56,7 +56,6 @@ jobs:
     steps:
       - run: exit 1
         name: "Catch errors"
-        if: ${{ contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled') }}
 
   dependency-review:
     name: Dependency Review


### PR DESCRIPTION
Result of this PR

* The validate job will only run on failure, so no spending costs if
code scanning is ok
* Use the ubuntu slim node since this is a very simple job

Signed-off-by: Atze de Vries <atze.wiebe.de.vries@coop.no>
